### PR TITLE
Fix button title attribute in editor.js to get tooltips for the buttons

### DIFF
--- a/lib/scripts/editor.js
+++ b/lib/scripts/editor.js
@@ -59,6 +59,7 @@ var dw_editor = {
         ], function (_, img) {
             var $btn = jQuery(document.createElement('button'))
                 .attr('type', 'button')
+                .attr('title', LANG['size_' + img[0])
                 .on('click', img[1])
                 .appendTo($ctl);
             jQuery(document.createElement('img'))


### PR DESCRIPTION
Several people have complained on the forum that these buttons lack tooltips, and their function is non-intuitive.

I agree, so here is a simple fix for that using the same localised string already being used for the alt attribute of the <img>.